### PR TITLE
Adds datalistId for prompt modals

### DIFF
--- a/src/lib/plugins/bootstrap/message-modal.component.ts
+++ b/src/lib/plugins/bootstrap/message-modal.component.ts
@@ -51,6 +51,7 @@ export class BSMessageModalTitle {
     <div [innerHtml]="context.message"></div>
       <div *ngIf="context.showInput" class="form-group">
         <input autofocus #input
+            [attr.list]="context.datalistId"
             name="bootstrap" 
             type="text" 
             class="form-control"

--- a/src/lib/plugins/bootstrap/presets/two-button-preset.ts
+++ b/src/lib/plugins/bootstrap/presets/two-button-preset.ts
@@ -84,16 +84,18 @@ export interface PromptPreset extends TwoButtonPreset {
   defaultValue: string;
   /** A placeholder for the input element. */
   placeholder: string;
-
+  /** An id of a datalist element that provides valid values for the input */
+  datalistId: string;
 }
 
 export class PromptPresetBuilder extends AbstractTwoButtonPresetBuilder {
   placeholder: FluentAssignMethod<string, this>;
+  datalistId: FluentAssignMethod<string, this>;
   defaultValue: FluentAssignMethod<string, this>;
 
   constructor(modal: Modal, defaultValues: PromptPreset = undefined) {
-    super(modal, extend<any>({showInput: true, defaultValue: ''}, defaultValues || {}),
-      ['placeholder', 'defaultValue']);
+    super(modal, extend<any>({showInput: true, defaultValue: '', datalistId: ''}, defaultValues || {}),
+      ['placeholder', 'defaultValue', 'datalistId']);
   }
 
   $$beforeOpen(config: PromptPreset): ResolvedReflectiveProvider[] {
@@ -107,4 +109,3 @@ export class PromptPresetBuilder extends AbstractTwoButtonPresetBuilder {
     return super.$$beforeOpen(config);
   }
 }
-


### PR DESCRIPTION
This PR is for issue #350.

The datalistId points to an id of a <datalist> element. The options
of this datalist element are used as the list attribute in the
<input> element of a prompt dialog.  Use it like this:

In your component template:

    <datalist id="my-list"><option value="1"><option value="2"></datalist>

In your component js:

    modal.prompt()
      .datalistId('my-list')
      .size('lg')
      .isBlocking(true)
      .showClose(true)
      .keyboard(27)
      .title('Hello World')
      .body('A Customized Modal')
      .open();

This adds options 1 and 2 as elements of the modal.