### PR TITLE
OutsideEventPlugin checks if teardown function is already defined before calling it

### DIFF
--- a/src/ngx-modialog/src/providers/outside-event-plugin.ts
+++ b/src/ngx-modialog/src/providers/outside-event-plugin.ts
@@ -81,7 +81,9 @@ export class DOMOutsideEventPlugin { // extends EventManagerPlugin
         return zone.runOutsideAngular(() => {
             let fn: Function;
             setTimeout(() => fn = onceOnOutside(), 0);
-            return () => fn();
+            return () => {
+                if (fn) fn();
+            };
         });
     }
 


### PR DESCRIPTION
In some cases,  in the addEventListener method of the OutsideEventPlugin class, the teardown function could be called before actually attaching the event and defining the teardown function, leading to a `fn is not a function` error, as reported in #239 