### PR TITLE
refactor: support angular version 5

### DIFF
--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -37,7 +37,7 @@ const util = require('../scripts/util.ts');
 const HMR = helpers.hasProcessFlag('hot');
 const AOT = process.env.BUILD_AOT || helpers.hasNpmFlag('aot');
 const METADATA = {
-  title: 'Angular Library Starter Demo App',
+  title: 'ngx-modialog',
   baseUrl: '/',
   isDevServer: helpers.isWebpackDevServer(),
   HMR: HMR

--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -133,6 +133,8 @@ module.exports = function (options) {
        * NOTE: when adding more properties, make sure you include them in custom-typings.d.ts
        */
       new DefinePlugin({
+        "VERSION": JSON.stringify(require(helpers.root('package.json')).version),
+        "NG_VERSION": JSON.stringify(require(helpers.root('node_modules', '@angular', 'core', 'package.json')).version),
         'ENV': JSON.stringify(METADATA.ENV),
         'HMR': METADATA.HMR,
         'process.env': {

--- a/config/webpack.prod.js
+++ b/config/webpack.prod.js
@@ -159,6 +159,8 @@ module.exports = function (options) {
        */
       // NOTE: when adding more properties make sure you include them in custom-typings.d.ts
       new DefinePlugin({
+        "VERSION": JSON.stringify(require(helpers.root('package.json')).version),
+        "NG_VERSION": JSON.stringify(require(helpers.root('node_modules', '@angular', 'core', 'package.json')).version),
         'ENV': JSON.stringify(METADATA.ENV),
         'HMR': METADATA.HMR,
         'process.env': {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ngx-modialog",
   "description": "Modal / Dialog for Angular",
-  "version": "3.0.2",
+  "version": "4.0.0-beta.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/shlomiassaf/ngx-modialog.git"
@@ -86,16 +86,16 @@
     "webpack": "node --max_old_space_size=4096 node_modules/webpack/bin/webpack.js"
   },
   "devDependencies": {
-    "@angular/animations": "^4.2.3",
-    "@angular/common": "^4.2.3",
-    "@angular/compiler": "^4.2.3",
-    "@angular/compiler-cli": "^4.2.3",
-    "@angular/core": "^4.2.3",
-    "@angular/forms": "^4.2.3",
-    "@angular/http": "^4.2.3",
-    "@angular/platform-browser": "^4.2.3",
-    "@angular/platform-browser-dynamic": "^4.2.3",
-    "@angular/platform-server": "^4.2.3",
+    "@angular/animations": "5.0.0-beta.3",
+    "@angular/common": "5.0.0-beta.3",
+    "@angular/compiler": "5.0.0-beta.3",
+    "@angular/compiler-cli": "5.0.0-beta.3",
+    "@angular/core": "5.0.0-beta.3",
+    "@angular/forms": "5.0.0-beta.3",
+    "@angular/http": "5.0.0-beta.3",
+    "@angular/platform-browser": "5.0.0-beta.3",
+    "@angular/platform-browser-dynamic": "5.0.0-beta.3",
+    "@angular/platform-server": "5.0.0-beta.3",
     "@angular/router": "^4.2.3",
     "@angularclass/hmr": "~1.2.2",
     "@angularclass/hmr-loader": "~3.0.2",

--- a/src/demo/app/bootstrap-demo/bootstrap-demo-page/bootstrap-demo-page.tpl.html
+++ b/src/demo/app/bootstrap-demo/bootstrap-demo-page/bootstrap-demo-page.tpl.html
@@ -10,7 +10,7 @@
         </div>
     </div>
 </demo-head>
-<ng-template #templateRef let-dialogRef="dialogRef" let-ctx="dialogRef.context">
+<ng-template #templateRef let-dialogRef="dialogRef" let-ctx>
     <div style="padding: 10px">
         <div class="page-header">
             <h1>TemplateRef Example</h1>

--- a/src/demo/app/home/home.tpl.html
+++ b/src/demo/app/home/home.tpl.html
@@ -4,6 +4,15 @@
             <div class="col-md-12"  overlayTarget="home-overlay-container">
             </div>
         </div>
+        <div class="row versions">
+            <div class="col-sm-12">
+                <small>Built with:</small>
+            </div>
+            <div class="col-sm-12">
+                <small><b>ngx-modialog</b> @ {{ version }} / <b>angular</b> @ {{ ngVersion }}</small>
+            </div>
+
+        </div>
     </div>
 </section>
 

--- a/src/demo/app/home/home.ts
+++ b/src/demo/app/home/home.ts
@@ -11,6 +11,9 @@ import { InAppModalModule, Modal } from './in-app-plugin/index';
 export class Home {
   @ViewChild('myTemplate', {read: TemplateRef}) public myTemplate: TemplateRef<any>;
 
+  readonly version = VERSION;
+  readonly ngVersion = NG_VERSION;
+
   constructor(private modal: Modal) {
   }
 

--- a/src/demo/app/home/in-app-plugin/modal.ts
+++ b/src/demo/app/home/in-app-plugin/modal.ts
@@ -24,16 +24,14 @@ export class Modal extends Modal_ {
     return new InAppModalContextBuilder(this);
   }
 
-  protected create(dialogRef: DialogRef<any>,
-                   content: ContainerContent,
-                   bindings?: RRP[]): Maybe<DialogRef<any>> {
+  protected create(dialogRef: DialogRef<any>, content: ContainerContent): Maybe<DialogRef<any>> {
     if (dialogRef.inElement) {
       dialogRef.overlayRef.instance.insideElement();
     } else {
       dialogRef.overlayRef.instance.fullscreen();
     }
 
-    dialogRef.overlayRef.instance.addComponent(InAppModalBackdrop, bindings);
+    dialogRef.overlayRef.instance.addComponent(InAppModalBackdrop);
 
     dialogRef.overlayRef.instance.setStyle('position', 'relative');
     dialogRef.overlayRef.instance.setStyle('display', 'block');

--- a/src/demo/custom-typings.d.ts
+++ b/src/demo/custom-typings.d.ts
@@ -57,6 +57,9 @@ declare module 'modern-lru' {
 */
 
 // Extra variables that live on Global that will be replaced by webpack DefinePlugin
+declare var VERSION: string;
+declare var NG_VERSION: string;
+declare var ENV: string;
 declare var ENV: string;
 declare var HMR: boolean;
 declare var System: SystemJS;

--- a/src/ngx-modialog/package.json
+++ b/src/ngx-modialog/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ngx-modialog",
   "description": "Modal / Dialog for Angular",
-  "version": "3.0.2",
+  "version": "4.0.0-beta.0",
   "libConfig": {
     "entry": "ngx-modialog",
     "inlineResources": true,

--- a/src/ngx-modialog/plugins/bootstrap/package.json
+++ b/src/ngx-modialog/plugins/bootstrap/package.json
@@ -1,3 +1,3 @@
 {
-  "version": "3.0.2"
+  "version": "4.0.0-beta.0"
 }

--- a/src/ngx-modialog/plugins/bootstrap/src/modal-container.component.ts
+++ b/src/ngx-modialog/plugins/bootstrap/src/modal-container.component.ts
@@ -2,7 +2,7 @@ import {
   Component,
   ElementRef,
   ViewEncapsulation,
-  Renderer
+  Renderer2
 } from '@angular/core';
 
 import { BaseDynamicComponent, DialogRef } from 'ngx-modialog';
@@ -29,7 +29,7 @@ import { MessageModalPreset } from'./presets/message-modal-preset';
 })
 export class BSModalContainer extends BaseDynamicComponent {
    constructor(public dialog: DialogRef<MessageModalPreset>,
-              el: ElementRef, renderer: Renderer) {
+              el: ElementRef, renderer: Renderer2) {
     super(el, renderer);
     this.activateAnimationListener();
   }

--- a/src/ngx-modialog/plugins/bootstrap/src/modal.ts
+++ b/src/ngx-modialog/plugins/bootstrap/src/modal.ts
@@ -1,9 +1,5 @@
 import { combineLatest } from 'rxjs/operator/combineLatest';
-
-import {
-  Injectable,
-  ResolvedReflectiveProvider as RRP
-} from '@angular/core';
+import { Injectable } from '@angular/core';
 
 import {
   Maybe,
@@ -51,12 +47,10 @@ export class Modal extends Modal_ {
     return new TwoButtonPresetBuilder(this, <any>{isBlocking: true, keyboard: null});
   }
 
-  protected create(dialogRef: DialogRef<any>,
-                   content: ContainerContent,
-                   bindings?: RRP[]): Maybe<DialogRef<any>> {
+  protected create(dialogRef: DialogRef<any>, content: ContainerContent): Maybe<DialogRef<any>> {
 
     const backdropRef = this.createBackdrop(dialogRef, CSSBackdrop);
-    const containerRef = this.createContainer(dialogRef, BSModalContainer, content, bindings);
+    const containerRef = this.createContainer(dialogRef, BSModalContainer, content);
 
     let overlay = dialogRef.overlayRef.instance;
     let backdrop = backdropRef.instance;

--- a/src/ngx-modialog/plugins/bootstrap/src/presets/one-button-preset.ts
+++ b/src/ngx-modialog/plugins/bootstrap/src/presets/one-button-preset.ts
@@ -1,4 +1,3 @@
-import { ResolvedReflectiveProvider } from '@angular/core';
 import { Modal, FluentAssignMethod, extend } from 'ngx-modialog';
 import { BSMessageModal } from '../message-modal.component';
 import { MessageModalPresetBuilder, MessageModalPreset } from './message-modal-preset';
@@ -35,13 +34,14 @@ export class OneButtonPresetBuilder extends MessageModalPresetBuilder<OneButtonP
     ]);
   }
 
-  $$beforeOpen(config: OneButtonPreset): ResolvedReflectiveProvider[] {
+  $$beforeOpen(config: OneButtonPreset): void {
+    super.$$beforeOpen(config);
+
     this.addButton(
       config.okBtnClass,
       config.okBtn,
       (cmp: BSMessageModal, $event: MouseEvent) => cmp.dialog.close(true)
     );
-    return super.$$beforeOpen(config);
   }
 }
 

--- a/src/ngx-modialog/plugins/bootstrap/src/presets/two-button-preset.ts
+++ b/src/ngx-modialog/plugins/bootstrap/src/presets/two-button-preset.ts
@@ -1,4 +1,3 @@
-import { ResolvedReflectiveProvider } from '@angular/core';
 import {
   Modal,
   FluentAssignMethod,
@@ -47,14 +46,13 @@ export abstract class AbstractTwoButtonPresetBuilder extends MessageModalPresetB
     ], initialSetters));
   }
 
-  $$beforeOpen(config: TwoButtonPreset): ResolvedReflectiveProvider[] {
+  $$beforeOpen(config: TwoButtonPreset): void {
+    super.$$beforeOpen(config);
     this.addButton(
       config.cancelBtnClass,
       config.cancelBtn,
       (cmp: BSMessageModal, $event: MouseEvent) => cmp.dialog.dismiss()
     );
-
-    return super.$$beforeOpen(config);
   }
 }
 
@@ -67,14 +65,13 @@ export class TwoButtonPresetBuilder extends AbstractTwoButtonPresetBuilder {
     super(modal, defaultValues);
   }
 
-  $$beforeOpen(config: TwoButtonPreset): ResolvedReflectiveProvider[] {
+  $$beforeOpen(config: TwoButtonPreset): void {
+    super.$$beforeOpen(config);
     this.addButton(
       config.okBtnClass,
       config.okBtn,
       (cmp: BSMessageModal, $event: MouseEvent) => cmp.dialog.close(true)
     );
-
-    return super.$$beforeOpen(config);
   }
 }
 
@@ -96,15 +93,14 @@ export class PromptPresetBuilder extends AbstractTwoButtonPresetBuilder {
       ['placeholder', 'defaultValue']);
   }
 
-  $$beforeOpen(config: PromptPreset): ResolvedReflectiveProvider[] {
+  $$beforeOpen(config: PromptPreset): void {
+    super.$$beforeOpen(config);
     this.addButton(
       config.okBtnClass,
       config.okBtn,
       (cmp: BSMessageModal, $event: MouseEvent) =>
         cmp.dialog.close((cmp.dialog.context as PromptPreset).defaultValue)
     );
-
-    return super.$$beforeOpen(config);
   }
 }
 

--- a/src/ngx-modialog/plugins/js-native/package.json
+++ b/src/ngx-modialog/plugins/js-native/package.json
@@ -1,3 +1,3 @@
 {
-  "version": "3.0.2"
+  "version": "4.0.0-beta.0"
 }

--- a/src/ngx-modialog/plugins/js-native/src/presets/js-native-preset.ts
+++ b/src/ngx-modialog/plugins/js-native/src/presets/js-native-preset.ts
@@ -1,4 +1,4 @@
-import { ViewContainerRef, ResolvedReflectiveProvider } from '@angular/core';
+import { ViewContainerRef } from '@angular/core';
 import { DialogRef, DROP_IN_TYPE, OverlayConfig } from 'ngx-modialog';
 import { Modal } from '../modal';
 
@@ -15,14 +15,6 @@ export class JSNativePresetBuilder extends JSNativeModalContextBuilder<JSNativeM
   }
 
   /**
-   * Hook to alter config and return bindings.
-   * @param config
-   */
-  protected $$beforeOpen(config: JSNativeModalContext): ResolvedReflectiveProvider[] {
-    return [];
-  }
-
-  /**
    * Open a modal window based on the configuration of this config instance.
    * @param viewContainer If set opens the modal inside the supplied viewContainer
    * @returns Promise<DialogRef>
@@ -34,11 +26,12 @@ export class JSNativePresetBuilder extends JSNativeModalContextBuilder<JSNativeM
       return <any>Promise.reject(new Error('Configuration Error: modal service not set.'));
     }
 
+    this.$$beforeOpen(context);
+
     let overlayConfig: OverlayConfig = {
       context: context,
       renderer: new JSNativeModalRenderer(),
-      viewContainer: viewContainer,
-      bindings: typeof this.$$beforeOpen === 'function' && this.$$beforeOpen(context)
+      viewContainer: viewContainer
     };
 
     return context.modal.open(context.component, overlayConfig);

--- a/src/ngx-modialog/plugins/vex/package.json
+++ b/src/ngx-modialog/plugins/vex/package.json
@@ -1,3 +1,3 @@
 {
-  "version": "3.0.2"
+  "version": "4.0.0-beta.0"
 }

--- a/src/ngx-modialog/plugins/vex/src/modal.ts
+++ b/src/ngx-modialog/plugins/vex/src/modal.ts
@@ -1,7 +1,6 @@
 import { Observable } from 'rxjs';
 import { combineLatest } from 'rxjs/operator/combineLatest';
-
-import { Injectable, ResolvedReflectiveProvider as RRP } from '@angular/core';
+import { Injectable } from '@angular/core';
 
 import {
   ContainerContent,
@@ -45,12 +44,10 @@ export class Modal extends Modal_ {
     }  as any);
   }
 
-  protected create(dialogRef: DialogRef<any>,
-                   content: ContainerContent,
-                   bindings?: RRP[]): Maybe<DialogRef<any>> {
+  protected create(dialogRef: DialogRef<any>, content: ContainerContent): Maybe<DialogRef<any>> {
 
     const backdropRef = this.createBackdrop(dialogRef, CSSBackdrop);
-    const containerRef = this.createContainer(dialogRef, CSSDialogContainer, content, bindings);
+    const containerRef = this.createContainer(dialogRef, CSSDialogContainer, content);
 
     let overlay = dialogRef.overlayRef.instance;
     let backdrop = backdropRef.instance;

--- a/src/ngx-modialog/plugins/vex/src/presets/dropin-preset.ts
+++ b/src/ngx-modialog/plugins/vex/src/presets/dropin-preset.ts
@@ -1,4 +1,3 @@
-import { ResolvedReflectiveProvider } from '@angular/core';
 import {
   DROP_IN_TYPE,
   FluentAssignMethod,
@@ -93,7 +92,9 @@ export class DropInPresetBuilder extends DialogPresetBuilder<DropInPreset> {
     );
   }
 
-  $$beforeOpen(config: DropInPreset): ResolvedReflectiveProvider[] {
+  $$beforeOpen(config: DropInPreset): void {
+    super.$$beforeOpen(config);
+
     if (config.okBtn) {
       this.addOkButton(config.okBtn);
     }
@@ -101,12 +102,12 @@ export class DropInPresetBuilder extends DialogPresetBuilder<DropInPreset> {
     switch (config.dropInType) {
       case DROP_IN_TYPE.prompt:
         config.defaultResult = undefined;
+        break;
       case DROP_IN_TYPE.confirm:
         if (config.cancelBtn) {
           this.addCancelButton(config.cancelBtn);
         }
         break;
     }
-    return super.$$beforeOpen(config);
   }
 }

--- a/src/ngx-modialog/src/components/base-dynamic-component.ts
+++ b/src/ngx-modialog/src/components/base-dynamic-component.ts
@@ -2,7 +2,7 @@ import {
   ComponentRef,
   ElementRef,
   OnDestroy,
-  Renderer
+  Renderer2
 } from '@angular/core';
 
 import { Observable } from 'rxjs/Observable';
@@ -42,7 +42,7 @@ export class BaseDynamicComponent implements OnDestroy {
   protected animationEnd: Subject<TransitionEvent | AnimationEvent>;
 
   constructor(protected el: ElementRef,
-              protected renderer: Renderer) {}
+              protected renderer: Renderer2) {}
   
   activateAnimationListener() {
     if (this.animationEnd) return;
@@ -58,7 +58,7 @@ export class BaseDynamicComponent implements OnDestroy {
    * @returns {ModalOverlay}
    */
   setStyle(prop: string, value: string): this {
-    this.renderer.setElementStyle(this.el.nativeElement, prop, value);
+    this.renderer.setStyle(this.el.nativeElement, prop, value);
     return this;
   }
 
@@ -68,13 +68,13 @@ export class BaseDynamicComponent implements OnDestroy {
 
   addClass(css: string, forceReflow: boolean = false): void {
     css.split(' ')
-      .forEach( c => this.renderer.setElementClass(this.el.nativeElement, c, true) );
+      .forEach( c => this.renderer.addClass(this.el.nativeElement, c) );
     if (forceReflow) this.forceReflow();
   }
 
   removeClass(css: string, forceReflow: boolean = false): void {
     css.split(' ')
-      .forEach( c => this.renderer.setElementClass(this.el.nativeElement, c, false) );
+      .forEach( c => this.renderer.removeClass(this.el.nativeElement, c) );
     if (forceReflow) this.forceReflow();
   }
 
@@ -91,9 +91,6 @@ export class BaseDynamicComponent implements OnDestroy {
   /**
    * Add a component, supply a view container ref.
    * Note: The components vcRef will result in a sibling.
-   * @param component The component to add
-   * @param vcRef The container to add to
-   * @param bindings Bindings to use (added on top of the ViewContainerRef)
    * @returns {Promise<ComponentRef<any>>}
    */
   protected _addComponent<T>(instructions: CreateComponentArgs): ComponentRef<T> {

--- a/src/ngx-modialog/src/components/css-backdrop.ts
+++ b/src/ngx-modialog/src/components/css-backdrop.ts
@@ -2,7 +2,7 @@ import {
   Component,
   ElementRef,
   ViewEncapsulation,
-  Renderer
+  Renderer2
 } from '@angular/core';
 
 import { BaseDynamicComponent } from './base-dynamic-component';
@@ -23,7 +23,7 @@ export class CSSBackdrop extends BaseDynamicComponent {
   public cssClass: string;
   public styleStr: string;
 
-  constructor(el: ElementRef, renderer: Renderer) {
+  constructor(el: ElementRef, renderer: Renderer2) {
     super(el, renderer);
     this.activateAnimationListener();
 

--- a/src/ngx-modialog/src/components/css-dialog-container.ts
+++ b/src/ngx-modialog/src/components/css-dialog-container.ts
@@ -1,17 +1,12 @@
 import {
   Component,
-  ComponentRef,
-  ViewContainerRef,
-  ResolvedReflectiveProvider,
-  ViewChild,
   ViewEncapsulation,
   ElementRef,
-  Renderer
+  Renderer2
 } from '@angular/core';
 
 import { BaseDynamicComponent } from './base-dynamic-component';
 import { DialogRef } from '../models/dialog-ref';
-import { Class } from '../framework/utils';
 
 /**
  * A component that acts as a top level container for an open modal window.
@@ -28,7 +23,7 @@ import { Class } from '../framework/utils';
 export class CSSDialogContainer extends BaseDynamicComponent {
 
   constructor(public dialog: DialogRef<any>,
-              el: ElementRef, renderer: Renderer) {
+              el: ElementRef, renderer: Renderer2) {
     super(el, renderer);
     this.activateAnimationListener();
   }

--- a/src/ngx-modialog/src/framework/createComponent.ts
+++ b/src/ngx-modialog/src/framework/createComponent.ts
@@ -3,21 +3,18 @@ import {
   ComponentFactory,
   ComponentFactoryResolver,
   Injector,
-  ViewContainerRef,
-  ReflectiveInjector,
-  ResolvedReflectiveProvider
+  ViewContainerRef
 } from '@angular/core';
 
 export interface CreateComponentArgs {
   component: any;
   vcRef: ViewContainerRef;
   injector?: Injector;
-  bindings?: ResolvedReflectiveProvider[];
   projectableNodes?: any[][];
 }
 
 export function createComponent(instructions: CreateComponentArgs): ComponentRef<any> {
-  const injector: Injector = getInjector(instructions);
+  const injector: Injector =  instructions.injector || instructions.vcRef.parentInjector;
   const cmpFactory: ComponentFactory<any>
     = injector.get(ComponentFactoryResolver).resolveComponentFactory(instructions.component);
 
@@ -31,12 +28,5 @@ export function createComponent(instructions: CreateComponentArgs): ComponentRef
   } else {
     return cmpFactory.create(injector);
   }
-}
-
-function getInjector(instructions: CreateComponentArgs) {
-  const ctxInjector = instructions.injector || instructions.vcRef.parentInjector;
-  return Array.isArray(instructions.bindings) && instructions.bindings.length > 0 ?
-    ReflectiveInjector.fromResolvedProviders(instructions.bindings, ctxInjector) : ctxInjector;
-
 }
 

--- a/src/ngx-modialog/src/models/modal-open-context.ts
+++ b/src/ngx-modialog/src/models/modal-open-context.ts
@@ -46,9 +46,7 @@ export abstract class ModalOpenContextBuilder<T extends ModalOpenContext>
    * Hook to alter config and return bindings.
    * @param config
    */
-  protected $$beforeOpen(config: T): ResolvedReflectiveProvider[] {
-    return [];
-  }
+  protected $$beforeOpen(config: T): void { }
 
   /**
    * Open a modal window based on the configuration of this config instance.
@@ -62,10 +60,11 @@ export abstract class ModalOpenContextBuilder<T extends ModalOpenContext>
       return <any>Promise.reject(new Error('Configuration Error: modal service not set.'));
     }
 
+    this.$$beforeOpen(context);
+
     let overlayConfig: OverlayConfig = {
       context: context,
-      viewContainer: viewContainer,
-      bindings: typeof this.$$beforeOpen === 'function' && this.$$beforeOpen(context)
+      viewContainer: viewContainer
     };
 
     return context.modal.open(context.component, overlayConfig);

--- a/src/ngx-modialog/src/models/tokens.ts
+++ b/src/ngx-modialog/src/models/tokens.ts
@@ -36,11 +36,6 @@ export interface OverlayConfig {
   injector?: Injector;
 
   /**
-   * Resolved providers that will inject into the component provided.
-   */
-  bindings?: ResolvedReflectiveProvider[];
-
-  /**
    * The element to block using the modal.
    */
   viewContainer?: WideVCRef;

--- a/src/ngx-modialog/src/providers/dom-modal-renderer.ts
+++ b/src/ngx-modialog/src/providers/dom-modal-renderer.ts
@@ -3,8 +3,7 @@ import {
   ViewContainerRef,
   ComponentRef,
   Injector,
-  Injectable,
-  ReflectiveInjector
+  Injectable
 } from '@angular/core';
 
 import { createComponent } from '../framework/createComponent';
@@ -24,15 +23,12 @@ export class DOMOverlayRenderer implements OverlayRenderer {
       injector = this.injector;
     }
 
-    const bindings = ReflectiveInjector.resolve([
-      { provide: DialogRef, useValue: dialog }
-    ]);
-
     const cmpRef = createComponent({
       component: ModalOverlay,
       vcRef,
-      injector,
-      bindings
+      injector: Injector.create([
+        { provide: DialogRef, useValue: dialog }
+      ], injector)
     });
 
     if (!vcRef) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,65 +2,65 @@
 # yarn lockfile v1
 
 
-"@angular/animations@^4.2.3":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/@angular/animations/-/animations-4.2.3.tgz#686926a69d0c9c26a9bcad26cd6fbd0245bb6c1b"
+"@angular/animations@5.0.0-beta.3":
+  version "5.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@angular/animations/-/animations-5.0.0-beta.3.tgz#74709377b94d38a7af04a406a3b68c9ed261da9c"
   dependencies:
     tslib "^1.7.1"
 
-"@angular/common@^4.2.3":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/@angular/common/-/common-4.2.3.tgz#e0173612eb6a9cf8dd50bd34c8a932dbce91d2bf"
+"@angular/common@5.0.0-beta.3":
+  version "5.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@angular/common/-/common-5.0.0-beta.3.tgz#750b6792b6f8fa7c0343754cada9b1c43eb38678"
   dependencies:
     tslib "^1.7.1"
 
-"@angular/compiler-cli@^4.2.3":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/@angular/compiler-cli/-/compiler-cli-4.2.3.tgz#33aa3fbf4d9879cc142a3ecce46996bec840c029"
+"@angular/compiler-cli@5.0.0-beta.3":
+  version "5.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@angular/compiler-cli/-/compiler-cli-5.0.0-beta.3.tgz#ea754ad801a19b1f001daab02316672dfd1ee641"
   dependencies:
-    "@angular/tsc-wrapped" "4.2.3"
+    "@angular/tsc-wrapped" "5.0.0-beta.3"
     minimist "^1.2.0"
     reflect-metadata "^0.1.2"
 
-"@angular/compiler@^4.2.3":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/@angular/compiler/-/compiler-4.2.3.tgz#e9cded47994cf4adb7522d778c46b1f7c5263302"
+"@angular/compiler@5.0.0-beta.3":
+  version "5.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@angular/compiler/-/compiler-5.0.0-beta.3.tgz#70c59a8b250eb9906334b81c462feab454255616"
   dependencies:
     tslib "^1.7.1"
 
-"@angular/core@^4.2.3":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/@angular/core/-/core-4.2.3.tgz#ab7329c18d4fd305872b82718ffae3e76e4d4549"
+"@angular/core@5.0.0-beta.3":
+  version "5.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@angular/core/-/core-5.0.0-beta.3.tgz#476cdb178a8e69366f48f60ab19550ff4e923f7b"
   dependencies:
     tslib "^1.7.1"
 
-"@angular/forms@^4.2.3":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/@angular/forms/-/forms-4.2.3.tgz#ff770f0a45f37cd99a7c20cedce560d018c9ca3b"
+"@angular/forms@5.0.0-beta.3":
+  version "5.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@angular/forms/-/forms-5.0.0-beta.3.tgz#db4b896204883823e57bd81709d8a879baaabb78"
   dependencies:
     tslib "^1.7.1"
 
-"@angular/http@^4.2.3":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/@angular/http/-/http-4.2.3.tgz#8a8ffc8fdfcfda1b92cfc335efc658edd4b6a67a"
+"@angular/http@5.0.0-beta.3":
+  version "5.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@angular/http/-/http-5.0.0-beta.3.tgz#56e3d0ff23ab3f85fa5bc7656fdd3fc1ab0a7ca1"
   dependencies:
     tslib "^1.7.1"
 
-"@angular/platform-browser-dynamic@^4.2.3":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/@angular/platform-browser-dynamic/-/platform-browser-dynamic-4.2.3.tgz#87ce41f5779d31cbc68c71db6bfeba216d135554"
+"@angular/platform-browser-dynamic@5.0.0-beta.3":
+  version "5.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@angular/platform-browser-dynamic/-/platform-browser-dynamic-5.0.0-beta.3.tgz#849cc93875a8e670c186050987d2fbebffe8f9bd"
   dependencies:
     tslib "^1.7.1"
 
-"@angular/platform-browser@^4.2.3":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/@angular/platform-browser/-/platform-browser-4.2.3.tgz#9a1accfc9e93a9561012bba037a04b41cedc0255"
+"@angular/platform-browser@5.0.0-beta.3":
+  version "5.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@angular/platform-browser/-/platform-browser-5.0.0-beta.3.tgz#64c142000fa3a4bbc9975319febf56af2798a8fc"
   dependencies:
     tslib "^1.7.1"
 
-"@angular/platform-server@^4.2.3":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/@angular/platform-server/-/platform-server-4.2.3.tgz#ade4506530bb180aa3f03552bbc67045b511d3ce"
+"@angular/platform-server@5.0.0-beta.3":
+  version "5.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@angular/platform-server/-/platform-server-5.0.0-beta.3.tgz#9492207c78a8f1bf7f38fd48a34fceb10d355e10"
   dependencies:
     parse5 "^3.0.1"
     tslib "^1.7.1"
@@ -72,9 +72,9 @@
   dependencies:
     tslib "^1.7.1"
 
-"@angular/tsc-wrapped@4.2.3":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/@angular/tsc-wrapped/-/tsc-wrapped-4.2.3.tgz#1983e65d9ca96395dd52a0a904acfe8ac8e5724d"
+"@angular/tsc-wrapped@5.0.0-beta.3":
+  version "5.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@angular/tsc-wrapped/-/tsc-wrapped-5.0.0-beta.3.tgz#d71c607b02eb6fe7091b908ef2ec97180ec52618"
   dependencies:
     tsickle "^0.21.0"
 


### PR DESCRIPTION
BREAKING CHANGE:
Angular version 5 comes with a breaking change which results in an internal breaking change which remove API options

Bindings are no longer supported when opening a modal.
Providing bindings was, from day one, a shortcut to a manual operation.
If you used bindings before, instead provide an injector with the bindings inside.

Most of the users should not feel this change as usage of bindings should be minimal.

If you wrote a plugin you should feel this, follow the change set for one
of the native plugins as an conversion example.