### PR TITLE
Use ngStyle to avoid triggering CSP

### DIFF
--- a/src/ngx-modialog/plugins/bootstrap/src/modal-container.component.ts
+++ b/src/ngx-modialog/plugins/bootstrap/src/modal-container.component.ts
@@ -22,7 +22,7 @@ import { MessageModalPreset } from'./presets/message-modal-preset';
 `<div [ngClass]="dialog.context.dialogClass" 
       [class.modal-lg]="dialog.context.size == \'lg\'"
       [class.modal-sm]="dialog.context.size == \'sm\'">
-  <div class="modal-content" style="display:block" role="document" overlayDialogBoundary>
+  <div class="modal-content" [ngStyle]="{display:'block'}" role="document" overlayDialogBoundary>
     <ng-content></ng-content>
   </div>    
 </div>`


### PR DESCRIPTION
**Problem**
If a strict Content Security Policy (CSP) is enabled, it will block modals from being opened because the template in modal-container.component.ts contains an inline style.

**Workaround:**
Allow "unsafe-inline" for styles in the CSP.

**Proposed solution in this PR:**
Use [ngStyle] instead of style=. [ngStyle] is not blocked by the browser even with a strict CSP.